### PR TITLE
Edit style elements 

### DIFF
--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -47,16 +47,16 @@ function DeckGLOverlay(
 }
 
 const styles = {
-  streets: "mapbox://styles/dhalpern/cl8n48kzu000a15p9o8z7wjmb",
-  satellite: "mapbox://styles/dhalpern/cldlspaaw000q01o091kg3q6e",
+  streets: "mapbox://styles/nmarchi0/clf7bjhzl004d01oazq30inr1",
+  satellite: "mapbox://styles/nmarchi0/clf7dy0u2000g01lc2ho5xn0s",
 };
 
 const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN!;
 
 const REGION_URL =
-  "https://d386ho3t0q1oea.cloudfront.net/region_map-2-10.pmtiles";
+  "https://d386ho3t0q1oea.cloudfront.net/regiontile-2-10.pmtiles";
 const BLOCK_URL =
-  "https://d386ho3t0q1oea.cloudfront.net/africa_map-9-14_simp3.pmtiles";
+  "https://d386ho3t0q1oea.cloudfront.net/blocktile-9-14.pmtiles";
 
 const loadOptions = {
   pmt: {

--- a/config/MapVariables.ts
+++ b/config/MapVariables.ts
@@ -16,7 +16,7 @@ const kComplexitySchema: MapVariableSchema = {
     "8": "#FF9859",
     "9": "#FFB857",
     "10+": "#FCD860",
-    "Off-network": "#DDDDDD"
+    "Off-network": "#F9F871"
   },
 };
 
@@ -24,7 +24,7 @@ const BlockTypeSchema: MapVariableSchema = {
   name: "Block Type",
   description: "The typography of the block as urban, peri-urban, or non-urban.",
   columnAccessors: {
-    region: "k_ls_labels",
+    region: "area_type",
     blocks: "area_type",
   },
   colorMapping: {
@@ -43,14 +43,22 @@ const PopulationSchema: MapVariableSchema = {
   },
   rangeType: "unclassified",
   colorMapping: {
-    1:'#FCFFFC',
-    5:'#F0F0E4',
-    10:'#D6D5D3',
-    20:'#B1B8C7',
-    40:'#8C9BA5',
-    100:'#5C6D7E',
-    200:'#34495E',
-    300:'#00204C',
+    1: "#440154",
+    5: "#481a6c",
+    10: "#472f7d",
+    25: "#414487",
+    50: "#39568c",
+    75: "#31688e",
+    100: "#2a788e",
+    200: "#23888e",
+    300: "#1f988b",
+    400: "#22a884",
+    500: "#35b779",
+    600: "#54c568",
+    700: "#7ad151",
+    800: "#a5db36",
+    900: "#d2e21b",
+    1000: "#fde725",
   }
 };
 

--- a/config/TooltipColumns.ts
+++ b/config/TooltipColumns.ts
@@ -11,42 +11,63 @@ export const tooltipColumns: Array<TooltipSchema> = [
   },
   {
     column: "agglosname",
-    label: "Agglomeration"
+    label: "Place name",
   },
   {
     column: "area_type",
-    label: "Block Type"
+    label: "Block type",
   },
   {
-    column: "k_complexity",
-    label: "Block Complexity",
+    column: "k_ls_labels",
+    label: "Block complexity",
+  },
+  {
+    column: "k_labels_detailed",
+    label: "Block complexity",
   },
   {
     column: "landscan_population_un",
-    label: "Population",
+    label: "Population estimate (LandScan)",
+    format: (v:number) => Math.round(v).toLocaleString()
+  },
+  {
+    column: "worldpop_population_un",
+    label: "Population estimate (WorldPop)",
     format: (v:number) => Math.round(v).toLocaleString()
   },
   {
     column: "landscan_population_un_density_hectare",
-    label: "Population Density (p/ha)",
+    label: "Population per hectare (LandScan)",
     format: (v:number) => (Math.round(v*100)/100).toLocaleString()
   },
   {
-    column: "landscan_population_un_density_hectare_log",
-    label: "Population Density (log)",
+    column: "worldpop_population_un_density_hectare",
+    label: "Population per hectare (WorldPop)",
     format: (v:number) => (Math.round(v*100)/100).toLocaleString()
+  },
+  {
+    column: "building_count",
+    label: "Number of buildings",
+    format: (v:number) => Math.round(v).toLocaleString()
   },
   {
     column: "block_hectares",
-    label: "Area (ha)",
+    label: "Block area (hectares)",
     format: (v:number) => (Math.round(v*100)/100).toLocaleString()
   },
   {
-    column: "block_geohash",
-    label: "Geohash"
+    column: "block_area_km2",
+    label: "Block area (kilometers square)",
+    format: (v:number) => (Math.round(v*100)/100).toLocaleString()
+  },
+  {
+    column: "average_building_area_m2",
+    label: "Average building area (meters square)",
+    format: (v:number) => (Math.round(v*100)/100).toLocaleString()
   },
   {
     column: "block_id",
-    label: "ID"
+    label: "Block ID",
   },
 ]
+


### PR DESCRIPTION
Small PR with edits to style elements in the tooltip, scales, mapbox styles, and hook up new pmtiles. 

Review of changes: 
- New pmtile links: replaced cloudfront links and the new PMTiles in the cloudtile repo were moved to the pmtiles2 repo and works with the cloudfront CDN. 
- Color scale: The pop density scale now uses viridis. 
- Mapbox Layer: The mapbox styles are public so should work, but let me know if a token is needed to access (they are on my nmarchi0 MapBox account). 
- Small edits to the tooltip display variables

